### PR TITLE
Backoffice configuration

### DIFF
--- a/app/code/MiniProject/Enquiry/Api/Data/EnquiryInterface.php
+++ b/app/code/MiniProject/Enquiry/Api/Data/EnquiryInterface.php
@@ -16,7 +16,7 @@ interface EnquiryInterface
      *
      * @param int $enquiryId
      */
-    public function setEnquiryId(int $enquiryId)
+    public function setEnquiryId(int $enquiryId);
 
     /**
      * Get First Name

--- a/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/Index.php
+++ b/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/Index.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MiniProject\Enquiry\Controller\Adminhtml\Index;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\View\Result\Page;
+
+class Index extends Action {
+    public function execute(): ResultInterface {
+        /** @var Page $page */
+        $page = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+
+        $page->setActiveMenu('MiniProject_Enquiry::enquiry');
+        $page->addBreadcrumb(__('Enquiries'), __('Enquiries'));
+        $page->addBreadcrumb(__('Manage Enquiries'), __('Manage Enquiries'));
+        $page->getConfig()->getTitle()->prepend(__('Enquiries'));
+
+        return $page;
+    }
+}

--- a/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/index.php
+++ b/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/index.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MiniProject\Enquiry\Controller\Adminhtml\index;
+
+class index
+{
+
+}

--- a/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/index.php
+++ b/app/code/MiniProject/Enquiry/Controller/Adminhtml/index/index.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace MiniProject\Enquiry\Controller\Adminhtml\index;
-
-class index
-{
-
-}

--- a/app/code/MiniProject/Enquiry/etc/acl.xml
+++ b/app/code/MiniProject/Enquiry/etc/acl.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::content">
+                    <resource id="Magento_Backend::content_elements">
+                        <resource id="Magento_Cms::page" title="Pages" translate="title" sortOrder="10">
+                            <resource id="Magento_Cms::save" title="Save Page" translate="title" sortOrder="10">
+                                <resource id="Magento_Cms::save_design" title="Edit Page Design" translate="title" />
+                            </resource>
+                            <resource id="Magento_Cms::page_delete" title="Delete Page" translate="title" sortOrder="20" />
+                        </resource>
+                        <resource id="Magento_Cms::block" title="Blocks" translate="title" sortOrder="30" />
+                        <resource id="Magento_Cms::media_gallery" title="Media Gallery" translate="title" sortOrder="70" />
+                    </resource>
+                </resource>
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Magento_Cms::config_cms" title="Content Management" translate="title" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/app/code/MiniProject/Enquiry/etc/acl.xml
+++ b/app/code/MiniProject/Enquiry/etc/acl.xml
@@ -1,31 +1,12 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
+
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::content">
                     <resource id="Magento_Backend::content_elements">
-                        <resource id="Magento_Cms::page" title="Pages" translate="title" sortOrder="10">
-                            <resource id="Magento_Cms::save" title="Save Page" translate="title" sortOrder="10">
-                                <resource id="Magento_Cms::save_design" title="Edit Page Design" translate="title" />
-                            </resource>
-                            <resource id="Magento_Cms::page_delete" title="Delete Page" translate="title" sortOrder="20" />
-                        </resource>
-                        <resource id="Magento_Cms::block" title="Blocks" translate="title" sortOrder="30" />
-                        <resource id="Magento_Cms::media_gallery" title="Media Gallery" translate="title" sortOrder="70" />
-                    </resource>
-                </resource>
-                <resource id="Magento_Backend::stores">
-                    <resource id="Magento_Backend::stores_settings">
-                        <resource id="Magento_Config::config">
-                            <resource id="Magento_Cms::config_cms" title="Content Management" translate="title" />
-                        </resource>
+                        <resource id="MiniProject_Enquiry::enquiry" title="Enquiries" translate="title" sortOrder="10" />
                     </resource>
                 </resource>
             </resource>

--- a/app/code/MiniProject/Enquiry/etc/adminhtml/menu.xml
+++ b/app/code/MiniProject/Enquiry/etc/adminhtml/menu.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add
+            id="MiniProject_Enquiry::enquiry"
+            title="Enquiries"
+            translate="title"
+            module="MiniProject_Enquiry"
+            sortOrder="0"
+            parent="Magento_Backend::content_elements"
+            action="enquiry"
+            resource="MiniProject_Enquiry::enquiry"
+        />
+    </menu>
+</config>

--- a/app/code/MiniProject/Enquiry/etc/adminhtml/routes.xml
+++ b/app/code/MiniProject/Enquiry/etc/adminhtml/routes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="cms" frontName="cms">
+            <module name="Magento_Cms" before="Magento_Backend" />
+        </route>
+    </router>
+</config>

--- a/app/code/MiniProject/Enquiry/etc/adminhtml/routes.xml
+++ b/app/code/MiniProject/Enquiry/etc/adminhtml/routes.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
+
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
-        <route id="cms" frontName="cms">
-            <module name="Magento_Cms" before="Magento_Backend" />
+        <route id="miniproject_enquiry" frontName="enquiry">
+            <module name="MiniProject_Enquiry" before="Magento_Backend" />
         </route>
     </router>
 </config>

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoryTreeTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoryTreeTest.php
@@ -610,16 +610,16 @@ QUERY;
         $categories = $response['categories']['items'];
         $storeBaseUrl = $this->objectManager->get(StoreManagerInterface::class)->getStore()->getBaseUrl('media');
         $expectedImageUrl = rtrim($storeBaseUrl, '/') . '/' . ltrim($categoryModel->getImage(), '/');
-        $expectedImageUrl = str_replace('index.php/', '', $expectedImageUrl);
+        $expectedImageUrl = str_replace('Index.php/', '', $expectedImageUrl);
 
         $this->assertEquals($categoryId, $categories[0]['id']);
         $this->assertEquals('Parent Image Category', $categories[0]['name']);
-        $categories[0]['image'] = str_replace('index.php/', '', $categories[0]['image']);
+        $categories[0]['image'] = str_replace('Index.php/', '', $categories[0]['image']);
         $this->assertEquals($expectedImageUrl, $categories[0]['image']);
 
         $childCategory = $categories[0]['children'][0];
         $this->assertEquals('Child Image Category', $childCategory['name']);
-        $childCategory['image'] = str_replace('index.php/', '', $childCategory['image']);
+        $childCategory['image'] = str_replace('Index.php/', '', $childCategory['image']);
         $this->assertEquals($expectedImageUrl, $childCategory['image']);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
@@ -421,8 +421,8 @@ QUERY;
         $categoryList = $response['categoryList'];
         $this->assertArrayNotHasKey('errors', $response);
         $this->assertNotEmpty($response['categoryList']);
-        $expectedImageUrl = str_replace('index.php/', '', $expectedImageUrl);
-        $categoryList[0]['image'] = str_replace('index.php/', '', $categoryList[0]['image']);
+        $expectedImageUrl = str_replace('Index.php/', '', $expectedImageUrl);
+        $categoryList[0]['image'] = str_replace('Index.php/', '', $categoryList[0]['image']);
         $this->assertEquals('Parent Image Category', $categoryList[0]['name']);
         $this->assertEquals($expectedImageUrl, $categoryList[0]['image']);
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -678,16 +678,16 @@ QUERY;
         $categoryList = $response['categoryList'];
         $storeBaseUrl = $this->objectManager->get(StoreManagerInterface::class)->getStore()->getBaseUrl('media');
         $expectedImageUrl = rtrim($storeBaseUrl, '/') . '/' . ltrim($categoryModel->getImage(), '/');
-        $expectedImageUrl = str_replace('index.php/', '', $expectedImageUrl);
+        $expectedImageUrl = str_replace('Index.php/', '', $expectedImageUrl);
 
         $this->assertEquals($categoryId, $categoryList[0]['id']);
         $this->assertEquals('Parent Image Category', $categoryList[0]['name']);
-        $categoryList[0]['image'] = str_replace('index.php/', '', $categoryList[0]['image']);
+        $categoryList[0]['image'] = str_replace('Index.php/', '', $categoryList[0]['image']);
         $this->assertEquals($expectedImageUrl, $categoryList[0]['image']);
 
         $childCategory = $categoryList[0]['children'][0];
         $this->assertEquals('Child Image Category', $childCategory['name']);
-        $childCategory['image'] = str_replace('index.php/', '', $childCategory['image']);
+        $childCategory['image'] = str_replace('Index.php/', '', $childCategory['image']);
         $this->assertEquals($expectedImageUrl, $childCategory['image']);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryWithDescriptionDirectivesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryWithDescriptionDirectivesTest.php
@@ -42,8 +42,8 @@ class CategoryWithDescriptionDirectivesTest extends GraphQlAbstract
         $storeManager = ObjectManager::getInstance()->get(StoreManagerInterface::class);
         $storeBaseUrl = $storeManager->getStore()->getBaseUrl();
 
-        /* Remove index.php from base URL */
-        $storeBaseUrlParts = explode('/index.php', $storeBaseUrl);
+        /* Remove Index.php from base URL */
+        $storeBaseUrlParts = explode('/Index.php', $storeBaseUrl);
         $storeBaseUrl = $storeBaseUrlParts[0];
 
         /** @var CategoryRepositoryInterface $categoryRepository */

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Environment.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Environment.php
@@ -21,7 +21,7 @@ class Environment
         // emulate HTTP request
         $serverVariables['HTTP_HOST'] = 'localhost';
         // emulate entry point to ensure that tests generate invariant URLs
-        $serverVariables['SCRIPT_FILENAME'] = 'index.php';
+        $serverVariables['SCRIPT_FILENAME'] = 'Index.php';
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
@@ -142,7 +142,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
     public function testGetHomePageUrl()
     {
         $this->assertStringEndsWith(
-            'index.php/backend/admin/',
+            'Index.php/backend/admin/',
             $this->_helper->getHomePageUrl(),
             'Incorrect home page URL'
         );

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/Session/AdminConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/Session/AdminConfigTest.php
@@ -31,7 +31,7 @@ class AdminConfigTest extends \PHPUnit\Framework\TestCase
     public function testConstructor()
     {
         $model = $this->objectManager->create(\Magento\Backend\Model\Session\AdminConfig::class);
-        $this->assertEquals('/index.php/backend', $model->getCookiePath());
+        $this->assertEquals('/Index.php/backend', $model->getCookiePath());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/ProductTest.php
@@ -125,7 +125,7 @@ class ProductTest extends AbstractBackendController
         $this->assertRedirect(
             $this->logicalNot(
                 $this->stringStartsWith(
-                    'http://localhost/index.php/backend/catalog/product/edit/id/' . $product->getEntityId() . '/'
+                    'http://localhost/Index.php/backend/catalog/product/edit/id/' . $product->getEntityId() . '/'
                 )
             )
         );

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
@@ -92,7 +92,7 @@ class CompareTest extends AbstractController
             $this->equalTo(
                 [
                     'You added product Simple Product 1 Name to the ' .
-                    '<a href="http://localhost/index.php/catalog/product_compare/">comparison list</a>.'
+                    '<a href="http://localhost/Index.php/catalog/product_compare/">comparison list</a>.'
                 ]
             ),
             MessageInterface::TYPE_SUCCESS

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/ViewTest.php
@@ -110,7 +110,7 @@ class ViewTest extends AbstractController
         $this->dispatch('catalog/product/view/id/1/');
 
         $this->assertContains(
-            '<link  rel="canonical" href="http://localhost/index.php/catalog/product/view/_ignore_category/1/id/1/" />',
+            '<link  rel="canonical" href="http://localhost/Index.php/catalog/product/view/_ignore_category/1/id/1/" />',
             $this->getResponse()->getBody()
         );
     }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Webapi/Product/Option/Type/File/ProcessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Webapi/Product/Option/Type/File/ProcessorTest.php
@@ -63,7 +63,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         return [
             // default config
             [[]],
-            // config from pub/index.php
+            // config from pub/Index.php
             [
                 [
                     DirectoryList::PUB => [DirectoryList::URL_PATH => ''],

--- a/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button/DeleteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button/DeleteTest.php
@@ -40,7 +40,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         self::assertStringContainsString('title="Remove"', $buttonHtml);
         self::assertStringContainsString(
             'this.setAttribute(\'data-url\', '
-            . '\'http://localhost/index.php/backend/admin/integration/delete/id/'
+            . '\'http://localhost/Index.php/backend/admin/integration/delete/id/'
             . $integration->getId(),
             $buttonHtml
         );
@@ -59,7 +59,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
         );
         self::assertStringContainsString(
             'this.setAttribute(\'data-url\', '
-            . '\'http://localhost/index.php/backend/admin/integration/delete/id/'
+            . '\'http://localhost/Index.php/backend/admin/integration/delete/id/'
             . $integration->getId(),
             $buttonHtml
         );

--- a/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button/EditTest.php
@@ -40,7 +40,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('title="Edit"', $buttonHtml);
         $this->assertStringContainsString('class="' .$this->editButtonBlock->escapeHtmlAttr('action edit') .'"', $buttonHtml);
         $this->assertStringContainsString(
-            'window.location.href=\'http://localhost/index.php/backend/admin/integration/edit/id/'
+            'window.location.href=\'http://localhost/Index.php/backend/admin/integration/edit/id/'
             . $integration->getId(),
             $buttonHtml
         );

--- a/dev/tests/integration/testsuite/Magento/PaypalGraphQl/_files/hosted_pro_nvp_request.php
+++ b/dev/tests/integration/testsuite/Magento/PaypalGraphQl/_files/hosted_pro_nvp_request.php
@@ -37,7 +37,7 @@ return [
     'L_BUTTONVAR18' => 'address1=Green str, 67',
     'L_BUTTONVAR19' => 'address2=',
     'L_BUTTONVAR20' => 'paymentaction=authorization',
-    'L_BUTTONVAR21' => 'notify_url=http://localhost/index.php/paypal/ipn/',
+    'L_BUTTONVAR21' => 'notify_url=http://localhost/Index.php/paypal/ipn/',
     'L_BUTTONVAR22' => 'cancel_return=' . $cancelUrl,
     'L_BUTTONVAR23' => 'return=' . $returnUrl,
     'L_BUTTONVAR24' => 'lc=US',

--- a/dev/tests/integration/testsuite/Magento/Store/App/FrontController/Plugin/RequestPreprocessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/App/FrontController/Plugin/RequestPreprocessorTest.php
@@ -60,7 +60,7 @@ class RequestPreprocessorTest extends \Magento\TestFramework\TestCase\AbstractCo
         $app = $this->_objectManager->create(\Magento\Framework\App\Http::class, ['_request' => $request]);
         $response = $app->launch();
         $redirectUrl = str_replace('http://', 'https://', $this->baseUrl) .
-            'index.php/customer/account/loginPost/';
+            'Index.php/customer/account/loginPost/';
         $this->assertResponseRedirect($response, $redirectUrl);
         $this->assertFalse($this->_objectManager->get(Session::class)->isLoggedIn());
         $this->setFrontendCompletelySecureRollback();
@@ -98,8 +98,8 @@ class RequestPreprocessorTest extends \Magento\TestFramework\TestCase\AbstractCo
         $request = [
             'REQUEST_SCHEME' => parse_url($requestUrl, PHP_URL_SCHEME),
             'SERVER_NAME' => parse_url($requestUrl, PHP_URL_HOST),
-            'SCRIPT_NAME' => '/index.php',
-            'SCRIPT_FILENAME' => 'index.php',
+            'SCRIPT_NAME' => '/Index.php',
+            'SCRIPT_FILENAME' => 'Index.php',
             'REQUEST_URI' => parse_url($requestUrl, PHP_URL_PATH),
         ];
         $this->setConfig($config);

--- a/dev/tests/integration/testsuite/Magento/Store/Model/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/Model/StoreTest.php
@@ -305,7 +305,7 @@ class StoreTest extends \PHPUnit\Framework\TestCase
 
         $this->model
             ->expects($this->any())->method('getUrl')
-            ->willReturn('http://localhost/index.php?' . SidResolverInterface::SESSION_ID_QUERY_PARAM . '=12345');
+            ->willReturn('http://localhost/Index.php?' . SidResolverInterface::SESSION_ID_QUERY_PARAM . '=12345');
         $this->request->setParams([SidResolverInterface::SESSION_ID_QUERY_PARAM, '12345']);
         $this->request->setQueryValue(SidResolverInterface::SESSION_ID_QUERY_PARAM, '12345');
         $this->assertStringContainsString(

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/EditTest.php
@@ -119,7 +119,7 @@ class EditTest extends TestCase
             );
 
             $this->assertMatchesRegularExpression(
-                '/http:\/\/localhost\/index.php\/.*\/category/',
+                '/http:\/\/localhost\/Index.php\/.*\/category/',
                 $categoryBlock->getItemUrl(),
                 'Child block with category contains invalid URL'
             );

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Product/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Product/EditTest.php
@@ -120,7 +120,7 @@ class EditTest extends TestCase
             );
 
             $this->assertMatchesRegularExpression(
-                '/http:\/\/localhost\/index.php\/.*\/product/',
+                '/http:\/\/localhost\/Index.php\/.*\/product/',
                 $productLinkBlock->getItemUrl(),
                 'Child block with product link contains invalid URL'
             );
@@ -151,7 +151,7 @@ class EditTest extends TestCase
             );
 
             $this->assertMatchesRegularExpression(
-                '/http:\/\/localhost\/index.php\/.*\/category/',
+                '/http:\/\/localhost\/Index.php\/.*\/category/',
                 $categoryLinkBlock->getItemUrl(),
                 'Child block with category link contains invalid URL'
             );

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Cms/Page/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Cms/Page/EditTest.php
@@ -103,7 +103,7 @@ class EditTest extends TestCase
             );
 
             $this->assertMatchesRegularExpression(
-                '/http:\/\/localhost\/index.php\/.*\/cms_page/',
+                '/http:\/\/localhost\/Index.php\/.*\/cms_page/',
                 $cmsPageLinkBlock->getItemUrl(),
                 'Child block with CMS page contains invalid URL'
             );

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Controller/Index/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Controller/Index/CartTest.php
@@ -84,7 +84,7 @@ class CartTest extends AbstractController
         $this->assertNotNull($item);
         $this->performAddToCartRequest(['item' => $item->getId(), 'qty' => 3]);
         $message = sprintf("\n" . 'You added %s to your ' .
-            '<a href="http://localhost/index.php/checkout/cart/">shopping cart</a>.', $item->getName());
+            '<a href="http://localhost/Index.php/checkout/cart/">shopping cart</a>.', $item->getName());
         $this->assertSessionMessages($this->equalTo([(string)__($message)]), MessageInterface::TYPE_SUCCESS);
         $this->assertCount(0, $this->getWishlistByCustomerId->execute(1)->getItemCollection());
         $cart = $this->cartFactory->create();

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/section-config.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Customer/frontend/js/section-config.test.js
@@ -81,7 +81,7 @@ define(['squire'], function (Squire) {
                 expect(obj.getAffectedSections('https://localhost.com/path/subpath')).toEqual(['section']);
             });
 
-            it('Strips "index.php" suffix from provided URL.', function () {
+            it('Strips "Index.php" suffix from provided URL.', function () {
                 obj['Magento_Customer/js/section-config']({
                     sections: {
                         'path': [

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -174,7 +174,7 @@
     RewriteCond %{REQUEST_FILENAME} !-l
 
 ############################################
-## Rewrite everything else to index.php
+## Rewrite everything else to Index.php
 
     RewriteRule .* index.php [L]
 


### PR DESCRIPTION
This implementation gives admin users management capabilities for modifying enquiries, for now, just to make such page exists in the admin panel

- menu.xml: this helps with adding a new menu item
- route.xml: this helps in making sure that the module renders before any magento backend modules
- acl.xml:  this is responsible for granting access to different operations (view operation of our MiniProject Enquiry) as stated in the menu.xml id attribute

- Controller/Adminhtml/Index/index.php:
    helps with handling requests to specific url in the admin panel and determines which contents to display in this context the enquiry page
    it works with the route.xml file 